### PR TITLE
decide in template the display of a first image

### DIFF
--- a/modules/frontend/journal/JournalFrontendModule.php
+++ b/modules/frontend/journal/JournalFrontendModule.php
@@ -39,10 +39,11 @@ class JournalFrontendModule extends DynamicFrontendModule {
 		}
 		$oListTemplate = $this->constructTemplate('teaser_list');
 		$oTeaserTemplate = $this->constructTemplate('journal_entry_teaser');
-		foreach($oJournalEntries as $i => $oJournalEntry) {
+		foreach($oJournalEntries as $iIndex => $oJournalEntry) {
 			$oTemplate = clone $oTeaserTemplate;
 			// show image of first journal entry teaser if a template identifier 'image_display_url' exists.
-			if($oTemplate->hasIdentifier('image_display_url') && $i === 0) {
+			if($oTemplate->hasIdentifier('image_display_url')) {
+				$oTemplate->replaceIdentifier('index', $iIndex);
 				$oImage = $oJournalEntry->getImages(1)->getFirst();
 				if($oImage) {
 					$oDocument = $oImage->getDocument();

--- a/modules/frontend/journal/templates/journal_entry_teaser_example.tmpl
+++ b/modules/frontend/journal/templates/journal_entry_teaser_example.tmpl
@@ -2,13 +2,14 @@
 Example of html for displaying first image of journal entry image gallery in teaser
 Change (or add) the template "journal_entry_teaser.tmpl" in site/modules/frontend/journal/templates/journal_entry_teaser.tmpl
 	- use "IdentifierContext" for displaying image related content, if exists
-	- optionally use lessThan (if=<) condition within this context, to limit view of image for a specific number of entries (...	2=2)
+	- optionally use lessThan (if=<) condition within this context, to limit view of image to a specific number of entries (...	2=3)
 For further information check JournalFrontendModule.php and Template related classes
 -->
 
 <h2><a href="{{link_to_detail}}" class="read_more" title="{{writeString=wns.read_more}}: „{{title}}“">{{title}}</a></h2>
 {{identifierContext=start;name=image_display_url}}
-{{if=<;1=\{\{index\}\};2=2}}
+// show the first image of journal gallery for first three entries, if they exist
+{{if=<;1=\{\{index\}\};2=3}}
 <p class="images">
 	<a href="{{link_to_detail}}" class="read_more" title="{{writeString=wns.read_more}}: {{title}}">
 		<img src="{{image_display_url}}" alt="{{image_description}}" width="{{image_width}}" height="{{image_height}}" />

--- a/modules/frontend/journal/templates/journal_entry_teaser_example.tmpl
+++ b/modules/frontend/journal/templates/journal_entry_teaser_example.tmpl
@@ -1,0 +1,24 @@
+<!-- 
+Example of html for displaying first image of journal entry image gallery in teaser
+Change (or add) the template "journal_entry_teaser.tmpl" in site/modules/frontend/journal/templates/journal_entry_teaser.tmpl
+	- use "IdentifierContext" for displaying image related content, if exists
+	- optionally use lessThan (if=<) condition within this context, to limit view of image for a specific number of entries (...	2=2)
+For further information check JournalFrontendModule.php and Template related classes
+-->
+
+<h2><a href="{{link_to_detail}}" class="read_more" title="{{writeString=wns.read_more}}: „{{title}}“">{{title}}</a></h2>
+{{identifierContext=start;name=image_display_url}}
+{{if=<;1=\{\{index\}\};2=2}}
+<p class="images">
+	<a href="{{link_to_detail}}" class="read_more" title="{{writeString=wns.read_more}}: {{title}}">
+		<img src="{{image_display_url}}" alt="{{image_description}}" width="{{image_width}}" height="{{image_height}}" />
+	</a>
+	<span class="legend">{{image_description}}</span>
+</p>
+{{endIf}}
+{{identifierContext=end;name=image_display_url}}
+<p class="journal_sub">
+	{{writeParameterizedString=journal.publish_date;date=\{\{date_timestamp\}\}}}{{identifierContext=start;name=user_name}}, {{user_name}}{{identifierContext=end;name=user_name}}
+</p>
+{{text_short}}
+<a href="{{link_to_detail}}" class="read_more">{{writeString=wns.read_more}}</a>


### PR DESCRIPTION
Instead of only being able to display the first image of the most recent (first) teaser entry, the user should be able to decide how many entries should display an image, including all. And best in the template, to avoid another configuration setting.

Change breaks the previous behavior: Instead of displaying the first (available) gallery image of the first journal teaser entry, all the entries would show this first image. But since there are most probably not many users out there that use the plugin or in particular the code to display this first image, I suggest this can be ignored. 